### PR TITLE
pg14 support added.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM timescale/timescaledb:latest-pg10
+FROM timescale/timescaledb:latest-pg14
 
 ADD replication.sh /docker-entrypoint-initdb.d/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Streaming Replication Container Setup for TimescaleDB
 
 Use this repository to launch a streaming replication enabled TimescaleDB
-cluster with 1 primary and 1 replica. It is based off of the `latest-pg10`
+cluster with 1 primary and 1 replica. It is based off of the `latest-pg14`
 TimescaleDB docker image.
 
 The `Dockerfile` takes advantage of PostgreSQL's [init script

--- a/stack.yml
+++ b/stack.yml
@@ -5,8 +5,6 @@ services:
     image: timescale-replication:latest
     env_file:
         - primary.env
-    environment:
-        REPLICATION_SUBNET: '10.0.0.0/24'
     ports:
         - 5432:5432
 


### PR DESCRIPTION
1. Image name replaced with pg14 version.
2. In the replica section more configs added which is similar to timescaledb documentation.
3. max_worker_processes , max_lock_per_transaction are added so that it have values greater than primary.
4. shared_preload_libraries added so that it won't give error during pg_ctl promote call
5. No need of REPLICATION_SUBNET as we can deduce inside container, this way it handle if other subnet introduce.